### PR TITLE
Prepare for release 0.1.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+build

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,5 +25,10 @@
     "strict": 0,
     "no-console": "off",
     "no-unused-vars":1
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Stage 0, "build-stage".
+FROM node:8 as build-stage
+WORKDIR /app
+COPY package*.json /app/
+# First install deps, then copy app and build.
+RUN yarn install
+COPY ./ /app/
+RUN yarn run build
+
+# Stage 1, "prod-stage".
+FROM nginx:stable
+COPY --from=build-stage /app/dist/ /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "publiccode-editor",
-  "version": "0.0.1",
-  "license": "CC0 1.0 Universal",
+  "version": "0.1.0",
+  "license": "CC0-1.0",
   "description": "[License](./LICENSE)",
   "scripts": {
     "dev": "webpack-dev-server --port 3000",
+    "lint": "eslint src/app/*.js",
     "build": "webpack",
     "test": "jest --watch"
   },
@@ -13,6 +14,10 @@
     "editor"
   ],
   "author": "Lorenzo Ponticelli <point.point@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:italia/publiccode-editor.git"
+  },
   "devDependencies": {
     "autoprefixer": "^7.1.6",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
In order to release the first version (0.1.0) here you may find the relevant checklist:
- [x] Setup linter (remember to include the linting passage before building)
- [x] Prepare Dockerfile
- [x] Prepare CI/CD environment
- [x] Populate README with deployment instructions
- [x] Bump version number in config files
- [x] Tag the last git commit with the version number