### PR TITLE
fix: linter in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "[License](./LICENSE)",
   "scripts": {
     "dev": "webpack-dev-server --port 3000",
-    "lint": "eslint src/app/*.js",
+    "lint": "eslint src/app/**/*.js",
     "build": "webpack",
     "test": "jest --watch"
   },


### PR DESCRIPTION
Fixing the linter. Now we get:  
`✖ 56 problems (15 errors, 41 warnings)`.
Probably is better to fix them in this PR and then merge. 