### PR TITLE
File extensions validator

### DIFF
--- a/src/app/contents/fields/generic.js
+++ b/src/app/contents/fields/generic.js
@@ -236,7 +236,8 @@ const fields = async () => {
       label: "Logo",
       description:
         "This key contains the logo of the software. Logos should be in vector format; raster formats are only allowed as a fallback. In this case, they should be transparent PNGs, minimum 1000px of width. Acceptable formats: SVG, SVGZ, PNG",
-      section: 2
+      section: 2,
+      fileExt: ['svg','svgz','png']
     },
     {
       type: "string",
@@ -244,7 +245,8 @@ const fields = async () => {
       label: "Logo Monochrome",
       description:
         "A monochromatic (black) logo. The logo should be in vector format; raster formats are only allowed as a fallback. In this case, they should be transparent PNGs, minimum 1000px of width. Acceptable formats: SVG, SVGZ, PNG",
-      section: 2
+      section: 2,
+      fileExt: ['svg','svgz','png']
     },
     {
       title: "developmentStatus",

--- a/src/app/utils/validate.js
+++ b/src/app/utils/validate.js
@@ -66,6 +66,15 @@ export const checkField = (field, obj, value, required) => {
   if (_.has(obj, 'maxLength') && !validator.isLength(strip(value).trim(), {min: undefined, max: obj.maxLength}))
     return "Not a valid input maximum length.";
 
+  if (_.has(obj, 'fileExt') && Array.isArray(obj.fileExt) && true) {
+    let extMatch = 0;
+    obj.fileExt.forEach(ext => {
+      if(value.toLowerCase().endsWith('.' + ext.toLowerCase()))
+        extMatch++;
+    });
+    if (extMatch == 0)
+      return "Not a valid extension, allowed only: " + obj.fileExt;
+  }
 
   if (obj && obj.widget) {
     let widget = obj.widget;

--- a/src/app/utils/validate.js
+++ b/src/app/utils/validate.js
@@ -69,7 +69,7 @@ export const checkField = (field, obj, value, required) => {
   if (_.has(obj, 'fileExt') && Array.isArray(obj.fileExt) && true) {
     let extMatch = 0;
     obj.fileExt.forEach(ext => {
-      if(value.toLowerCase().endsWith('.' + ext.toLowerCase()))
+      if(value.toLowerCase().split('.').pop() == ext.toLowerCase())
         extMatch++;
     });
     if (extMatch == 0)

--- a/src/app/utils/validate.js
+++ b/src/app/utils/validate.js
@@ -66,14 +66,14 @@ export const checkField = (field, obj, value, required) => {
   if (_.has(obj, 'maxLength') && !validator.isLength(strip(value).trim(), {min: undefined, max: obj.maxLength}))
     return "Not a valid input maximum length.";
 
-  if (_.has(obj, 'fileExt') && Array.isArray(obj.fileExt) && true) {
+  if (_.has(obj, 'fileExt') && Array.isArray(obj.fileExt)) {
     let extMatch = 0;
     obj.fileExt.forEach(ext => {
       if(value.toLowerCase().split('.').pop() == ext.toLowerCase())
         extMatch++;
     });
     if (extMatch == 0)
-      return "Not a valid extension, allowed only: " + obj.fileExt;
+      return `Not a valid extension, allowed only: ${obj.fileExt}`;
   }
 
   if (obj && obj.widget) {


### PR DESCRIPTION
Publiccode specs for monochromeLogo and logo allows only image formats with transparent channel.
More info on #57. 
Any file field can be restricted to a preset file extensions list.