### PR TITLE
Remove master from testing with cci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
       - checkout
       # Run install 
       - run: yarn install
+      # Run lint
+      - run: yarn lint
       # Build 
       - run: export ELASTIC_URL=$ELASTIC_URL_ENV && yarn build-prod 
       # Check `rsync` 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,5 +61,5 @@ workflows:
       - build-and-test:
           filters:
             branches:
-              only:
-                - /release-*.*/ 
+                ignore:
+                 - master


### PR DESCRIPTION
Removed master from testing with cci.
However, I'm not so convinced about this since I'd like to run the test on master before continuing just in case (e.g., someone pushes directly to master). 
@sebbalex should we copy-paste the same "tests" lines used in `build-and-test` also in the `build-and-deploy`?
Which are this ones btw https://github.com/italia/publiccode-editor/blob/63e855ae5b04107354e3cdcf9ade3885a9dbb8ae/.circleci/config.yml#L47-L50
 What do you think? 