### PR TITLE
External validation by GO parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # Run test
       - run: yarn test
       # Build 
-      - run: export ELASTIC_URL=$ELASTIC_URL_ENV && yarn build-prod 
+      - run: export ELASTIC_URL=$ELASTIC_URL_ENV && export VALIDATOR_URL=$VALIDATOR_URL && yarn build-prod 
       # Check `rsync` 
       - run: which rsync || sudo apt-get update && sudo apt-get install -y rsync
       # Add to known hosts

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -27,6 +27,14 @@ export default class App extends Component {
   render() {
     return (
       <Provider store={store}>
+        {this.state.loadingRemote && (
+        <div className="d-flex align-items-center col-12 position-absolute h-100 w-100">
+          <div className="mr-auto ml-auto">
+            <h3>Validazione in corso</h3>
+            <div className="spinner-grow text-primary" role="status" aria-hidden="true"></div>
+          </div>
+        </div>
+        )}
         <Layout loadingRemote={this.state.loadingRemote}>
           <Index onLoadingRemote={this.handleLoading} />
         </Layout>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -12,11 +12,23 @@ window.jQuery = $;
 window.$ = $;
 
 export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.handleLoading = this.handleLoading.bind(this);
+    this.state = {
+      loadingRemote: false
+    };
+  }
+
+  handleLoading(isLoading) {
+    this.setState({loadingRemote: isLoading})
+  }
+
   render() {
     return (
       <Provider store={store}>
-        <Layout>
-          <Index />
+        <Layout loadingRemote={this.state.loadingRemote}>
+          <Index onLoadingRemote={this.handleLoading} />
         </Layout>
       </Provider>
     );

--- a/src/app/components/_layout.js
+++ b/src/app/components/_layout.js
@@ -40,8 +40,11 @@ class Layout extends Component {
     }
   }
   render() {
+    const loadingRemote = this.props.loadingRemote;
+
+    const className = loadingRemote ? "wrapper loadingRemote" : "wrapper";
     return (
-      <div className="wrapper">
+      <div className={className}>
         <ReactNotify ref="notificator" />
         {this.props.children}
       </div>

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -182,7 +182,7 @@ class Index extends Component {
     let currentLanguage = languages ? languages[0] : null;
 
     // console.log(formValues, values);
-    
+
     values[currentLanguage] = formValues;
     let obj = ft.transform(values, country, elements);
 
@@ -192,13 +192,13 @@ class Index extends Component {
     //using Object.assign(obj, staticFieldsJson)
     //something weird occur.
     //needs to investigate further
-    obj['publiccodeYmlVersion']  = '0.2';
+    obj['publiccodeYmlVersion'] = '0.2';
 
     return postDataForValidation(obj)
       .then(this.validateExt)
       .then(v => {
         //everithing fine
-        console.log(v);
+        // console.log(v);
         return this.showResults(v);
       })
       .catch(e => {
@@ -210,20 +210,20 @@ class Index extends Component {
               let key = x.Key.replace(/\/\*\//gi, '_');
 
               //replacing separator section from field
-              key = key.replace(/\//gi,'_'); //replace / with _
-              
+              key = key.replace(/\//gi, '_'); //replace / with _
+
               //BUG
               //removing language
               //this issue is well known: editor do not validate multi language
               //pc since its fields are not named following a lang sintax
-              key = key.replace(/_it_/gi,'_'); //replace _it_ with _
+              key = key.replace(/_it_/gi, '_'); //replace _it_ with _
 
               //description appear when a language is not set
               //avoided for the moment
-              if(key!='description')
+              if (key != 'description')
                 errorObj[key] = x.Reason;
             });
-            console.log(errorObj);
+            // console.log(errorObj);
 
             // this.props.notify({ type: "error", msg: "Error in validation!" });
             // this.props.form[APP_FORM].syncErrors = errorObj
@@ -240,11 +240,28 @@ class Index extends Component {
           })
         } else {
           //generic error use internal validator
-          this.props.notify({ type: "error", msg: "Generic Error in validation!" });
-          console.error('Generic error', e);
-          
+          console.error('Generic error with remote validation, using local instead', e);
+
           //not working at the moment
-          this.validate(formValues);
+          //need to figure out why _error subkey
+          //cause a crash
+          let errorObj = this.validate(formValues);
+          let err = {};
+          Object.keys(errorObj).forEach(x => {
+            if (!errorObj[x]._error)
+              err[x] = errorObj[x];
+          });
+          console.log(err);
+
+
+          if (Object.keys(err).length === 0 && err.constructor === Object) {
+            this.showResults(obj);
+          } else {
+            this.setState({
+              errors: err
+            })
+            throw new SubmissionError(err);
+          }
         }
       });
 
@@ -527,7 +544,7 @@ class Index extends Component {
 
     if (form && form[APP_FORM]) {
       // console.log(form[APP_FORM]);
-      
+
       // errors =
       //   form[APP_FORM] && form[APP_FORM].submitErrors
       //     ? form[APP_FORM].submitErrors

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -198,11 +198,14 @@ class Index extends Component {
     return postDataForValidation(obj)
       .then(this.validateExt)
       .then(v => {
-        //  everithing fine
+        //  everything fine
         // console.log(v);
+
         this.setState({ loading: false });
         this.props.onLoadingRemote(false);
-        return this.showResults(v);
+        // removing empty object
+        // which caused a object {} in yaml results
+        return this.showResults(this.removeEmpty(v));
       })
       .catch(e => {
         if (e instanceof SubmissionError) {
@@ -274,6 +277,16 @@ class Index extends Component {
           }
         }
       });
+  }
+
+  removeEmpty(obj) {
+    // looking forward to replace with bind()
+    const that = this;
+    Object.keys(obj).forEach(function(key) {
+      (Object.keys(obj[key]).length === 0 && obj[key].constructor === Object) && delete obj[key] ||
+      (obj[key] && typeof obj[key] === 'object') && that.removeEmpty(obj[key])
+    });
+    return obj;
   }
 
   showResults(values) {

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -6,8 +6,7 @@ import { setVersions } from "../store/cache";
 import { APP_FORM } from "../contents/constants";
 import {
   getData,
-  SUMMARY,
-  gpostDataForValidation
+  SUMMARY
 } from "../contents/data";
 import jsyaml from "../../../node_modules/js-yaml/dist/js-yaml.js";
 
@@ -225,7 +224,7 @@ class Index extends Component {
             });
             // console.log(errorObj);
 
-            //errors are now taken from state, see line 535 for details
+            //errors are now taken from state, see line 507 for details
             // this.props.form[APP_FORM].submitErrors = errorObj
 
             //errors are in state now
@@ -287,6 +286,8 @@ class Index extends Component {
     let { yaml, yamlLoaded } = this.state;
     let type = "success";
     let msg = "Success";
+    
+    //was syncErrors
     if (form[APP_FORM].submitErrors) {
       type = "error";
       msg = "There are some errors";
@@ -506,8 +507,7 @@ class Index extends Component {
     let { form } = this.props;
 
     if (form && form[APP_FORM]) {
-      // console.log(form[APP_FORM]);
-
+      //errors are in state now
       // errors =
       //   form[APP_FORM] && form[APP_FORM].submitErrors
       //     ? form[APP_FORM].submitErrors
@@ -529,8 +529,6 @@ class Index extends Component {
                   onSubmit={this.validateAndGenerate.bind(this)}
                   data={blocks}
                   // validate={this.validate.bind(this)}
-                  // validate={this.validateAndGenerate.bind(this)}
-                  // asyncValidate={this.validateAndGenerate.bind(this)}
                   country={country}
                   switchCountry={this.switchCountry.bind(this)}
                   errors={errors}

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -225,8 +225,7 @@ class Index extends Component {
             });
             // console.log(errorObj);
 
-            // this.props.notify({ type: "error", msg: "Error in validation!" });
-            // this.props.form[APP_FORM].syncErrors = errorObj
+            //errors are now taken from state, see line 535 for details
             // this.props.form[APP_FORM].submitErrors = errorObj
 
             //errors are in state now
@@ -242,9 +241,11 @@ class Index extends Component {
           //generic error use internal validator
           console.error('Generic error with remote validation, using local instead', e);
 
+          //BUG
           //not working at the moment
-          //need to figure out why _error subkey
+          //need to figure out why _error subkeys
           //cause a crash
+          //this will cause a wrong validation for subkeys
           let errorObj = this.validate(formValues);
           let err = {};
           Object.keys(errorObj).forEach(x => {
@@ -264,44 +265,6 @@ class Index extends Component {
           }
         }
       });
-
-    //manipulate server side errors
-    //errors data should be like:
-    // {
-    //   "name": "This property is required.",
-    //   "description_genericName": "This property is required.",
-    //   "url": "This property is required.",
-    //   "releaseDate": "This property is required.",
-    //   "developmentStatus": "This property is required.",
-    //   "softwareType": "This property is required.",
-    //   "platforms": {
-    //     "_error": "Required"
-    //   },
-    //   "legal_license": {
-    //     "_error": "Required"
-    //   },
-    //   "description_shortDescription": "This property is required.",
-    //   "description_longDescription": "This property is required.",
-    //   "description_features": {
-    //     "_error": "Required"
-    //   },
-    //   "localisation_availableLanguages": {
-    //     "_error": "Required"
-    //   },
-    //   "categories": {
-    //     "_error": "Required"
-    //   },
-    //   "maintenance_type": {
-    //     "_error": "Required"
-    //   }
-    // }
-
-    // this.setState({
-    //   currentValues: contents,
-    //   values,
-    //   loading: true,
-    //   error: null
-    // });
   }
 
   showResults(values) {

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -307,7 +307,7 @@ class Index extends Component {
     let { yaml, yamlLoaded } = this.state;
     let type = "success";
     let msg = "Success";
-    if (form[APP_FORM].syncErrors) {
+    if (form[APP_FORM].submitErrors) {
       type = "error";
       msg = "There are some errors";
       yaml = null;

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -176,6 +176,7 @@ class Index extends Component {
     // let errors = {};
 
     this.setState({ loading: true, lastGen });
+    this.props.onLoadingRemote(true);
     //has state
     let { values, country, elements, languages } = this.state;
     let currentLanguage = languages ? languages[0] : null;
@@ -186,18 +187,21 @@ class Index extends Component {
     let obj = ft.transform(values, country, elements);
 
     this.fakeLoading();
-    console.log(obj);
+    // console.log(obj);
 
-    //using Object.assign(obj, staticFieldsJson)
-    //something weird occur.
-    //needs to investigate further
+    //  using 
+    //  Object.assign(obj, staticFieldsJson)
+    //  something weird occur.
+    //  needs to investigate further
     obj['publiccodeYmlVersion'] = '0.2';
 
     return postDataForValidation(obj)
       .then(this.validateExt)
       .then(v => {
-        //everithing fine
+        //  everithing fine
         // console.log(v);
+        this.setState({ loading: false });
+        this.props.onLoadingRemote(false);
         return this.showResults(v);
       })
       .catch(e => {
@@ -231,8 +235,10 @@ class Index extends Component {
             //but in sidebar are rendered from form.submitErrors
             //state there is not updated
             this.setState({
-              errors: errorObj
+              errors: errorObj,
+              loading: false
             })
+            this.props.onLoadingRemote(false);
 
             throw new SubmissionError(errorObj);
           })
@@ -253,6 +259,10 @@ class Index extends Component {
           });
           console.log(err);
 
+          this.setState({
+            loading: false
+          })
+          this.props.onLoadingRemote(false);
 
           if (Object.keys(err).length === 0 && err.constructor === Object) {
             this.showResults(obj);

--- a/src/app/components/editorForm.js
+++ b/src/app/components/editorForm.js
@@ -117,6 +117,7 @@ const EditForm = props => {
   
   let sectionsWithErrors = [];
   //submitFailed &&
+  
   if (submitFailed && errors) {
     sectionsWithErrors = Object.keys(errors).reduce((s, e) => {
       let field = getFieldByTitle(allFields, e);

--- a/src/app/components/sidebar.js
+++ b/src/app/components/sidebar.js
@@ -131,8 +131,8 @@ class sidebar extends Component {
 
     if (form && form[APP_FORM]) {
       errors =
-        form[APP_FORM] && form[APP_FORM].syncErrors
-          ? form[APP_FORM].syncErrors
+        form[APP_FORM] && form[APP_FORM].submitErrors
+          ? form[APP_FORM].submitErrors
           : null;
       fail = form[APP_FORM].submitFailed ? form[APP_FORM].submitFailed : false;
     }

--- a/src/app/components/sidebar.js
+++ b/src/app/components/sidebar.js
@@ -130,6 +130,7 @@ class sidebar extends Component {
     let fail = false;
 
     if (form && form[APP_FORM]) {
+      //was syncErrors
       errors =
         form[APP_FORM] && form[APP_FORM].submitErrors
           ? form[APP_FORM].submitErrors

--- a/src/app/contents/constants.js
+++ b/src/app/contents/constants.js
@@ -1,8 +1,9 @@
-let {REPOSITORY, ELASTIC_URL} = process.env;
+let {REPOSITORY, ELASTIC_URL, VALIDATOR_URL} = process.env;
 
 export const privacyPolicyUrl = `https://developers.italia.it/it/privacy-policy/`;
 export const repositoryUrl = `https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/`;
 export const versionsUrl = `https://api.github.com/repos/${REPOSITORY}/contents/version`;
 export const sampleUrl = `https://raw.githubusercontent.com/italia/publiccode.yml/master/docs/it/example/publiccode.minimal.yml`;
 export const elasticUrl = ELASTIC_URL || '';
+export const validatorUrl = VALIDATOR_URL || '';
 export const APP_FORM = "appForm";

--- a/src/app/utils/calls.js
+++ b/src/app/utils/calls.js
@@ -1,3 +1,5 @@
+import { SubmissionError } from "redux-form";
+
 export const getReleases = versionsUrl => {
   return fetch(versionsUrl)
     .then(res => res.json())
@@ -11,4 +13,21 @@ export const getRemoteYml = url => {
   return fetch(url)
     .then(res => res.json())
     .then(data => atob(data.content));
+};
+
+export const postDataForValidation = data => {
+  var myHeaders = new Headers({
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  });
+  const url = "http://localhost:5000/pc/payload"
+
+  var myInit = {
+    method: 'POST',
+    headers: myHeaders,
+    mode: 'cors',
+    cache: 'default',
+    body: JSON.stringify(data)
+  };
+  return fetch(url, myInit);
 };

--- a/src/app/utils/calls.js
+++ b/src/app/utils/calls.js
@@ -1,4 +1,4 @@
-import { SubmissionError } from "redux-form";
+import { validatorUrl } from "../contents/constants";
 
 export const getReleases = versionsUrl => {
   return fetch(versionsUrl)
@@ -20,7 +20,7 @@ export const postDataForValidation = data => {
     'Accept': 'application/json',
     'Content-Type': 'application/json'
   });
-  const url = "http://localhost:5000/pc/payload"
+  const url = validatorUrl;
 
   var myInit = {
     method: 'POST',
@@ -29,5 +29,9 @@ export const postDataForValidation = data => {
     cache: 'default',
     body: JSON.stringify(data)
   };
+  
+  if(url=='')
+    return Promise.reject(new Error('no validator url specified'));
+
   return fetch(url, myInit);
 };

--- a/src/asset/wrapper.scss
+++ b/src/asset/wrapper.scss
@@ -8,6 +8,12 @@
   overflow: hidden;
 }
 
+.wrapper.loadingRemote {
+  filter: blur(8px);
+  -webkit-filter: blur(8px);
+}
+
+
 @media all and (max-width: $mq-size) {
   .wrapper {
     overflow: auto;

--- a/src/asset/wrapper.scss
+++ b/src/asset/wrapper.scss
@@ -13,6 +13,15 @@
   -webkit-filter: blur(8px);
 }
 
+.d-flex.align-items-center.col-12.position-absolute.h-100 {
+  z-index: 9999;
+}
+.spinner-grow {
+  margin-left: 30px;
+  height: 10rem;
+  width: 10rem;
+}
+
 
 @media all and (max-width: $mq-size) {
   .wrapper {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = env => {
       new webpack.DefinePlugin({
         "process.env": {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
-          ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL)
+          ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
+          VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL)
         }
       }),
       new HtmlWebpackPlugin({

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -29,7 +29,8 @@ module.exports = env => {
       new webpack.DefinePlugin({
         "process.env": {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
-          ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL)
+          ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
+          VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL)
         }
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
This PR is intended to implement a more consistent way of validate publiccode as specified in #32 here we will collect data, tests and debate.

External validation using same library used by crawler to be more consistent. It is accomplished through a [proxy](https://github.com/italia/pc-web-validator) service who exposes rest API to interoperate.

- It will be exported always the latest `publiccodeYmlVersion` version
- Some keys could be tuned agreeing latest publiccodeYmlVersion specs.
- It adds a network layer of validation for fields who is required such as `url`, `apiDocumentation` and so on.
- `logo` and `screenshots`  are checked as well for their presence.
- It adds a little overhead due to remote checks, a loading mask is there for the purpose.

Fixes also #87, #86, #69, #65
#56?
And archives #35