### PR TITLE
Forced break-words for long line

### DIFF
--- a/src/asset/editor_widget.scss
+++ b/src/asset/editor_widget.scss
@@ -32,3 +32,8 @@ input.rw-widget-input {
 .riuso-box {
   min-height: 300px;
 }
+
+//fixes #98 - Editor area grows when unbreaked words
+.editor__component .public-DraftEditor-content {
+  word-break: break-all;
+}


### PR DESCRIPTION
As pointed out by @bfabio in #98 when a long line in `longDescription` will breaks the layout with an unexpected container horizontal grows.