### PR TITLE
Allow more protocols in URL fields.

### DIFF
--- a/src/app/contents/fields/generic.js
+++ b/src/app/contents/fields/generic.js
@@ -68,7 +68,7 @@ const fields = async () => {
       type: "string",
       description:
         "A unique identifier for this software. This string must be a URL to the source code repository (git, svn, ...) in which the software is published. If the repository is available under multiple protocols, prefer HTTP/HTTPS URLs which don't require user authentication.",
-      widget: "url",
+      widget: "repourl",
       section: 1,
       required: true
     },
@@ -218,7 +218,7 @@ const fields = async () => {
       description:
         "In case this software is a variant or a fork of another software, which might or might not contain a publiccode.yml file, this key will contain the url of the original project(s). The existence of this key identifies the fork as a software variant, descending from the specified repositories.",
       section: 2,
-      widget: "url"
+      widget: "repourl"
     },
 
     {

--- a/src/app/form/widgets/UrlWidget.js
+++ b/src/app/form/widgets/UrlWidget.js
@@ -2,7 +2,7 @@ import React from "react";
 import BaseInputWidget from "./BaseInputWidget";
 
 const UrlWidget = props => {
-  return <BaseInputWidget type="url" {...props} />;
+  return <BaseInputWidget type="url" placeholder="https://" {...props} />;
 };
 
 export default UrlWidget;

--- a/src/app/form/widgets/index.js
+++ b/src/app/form/widgets/index.js
@@ -45,6 +45,7 @@ export default {
   password: PasswordWidget,
   search: SearchWidget,
   url: UrlWidget,
+  repourl: UrlWidget,
   color: ColorWidget,
   choice: ChoiceWidget,
   "choice-expanded": ChoiceExpandedWidget,

--- a/src/app/utils/validate.js
+++ b/src/app/utils/validate.js
@@ -83,7 +83,19 @@ export const checkField = (field, obj, value, required) => {
       return "This property is required.";
 
     if (widget == "url" && !validator.isURL(value, {require_protocol: true})) {
-      return "Not a valid Url";
+      return "Not a valid URL";
+    }
+    if (widget == "repourl"
+        && !validator.isURL(value, {require_protocol: true})
+        // Eg. ssh://example.com/repo.git
+        //     git://example.com/repo.git
+        //     svn://example.com/repo
+        //     svn+ssh://example.com/repo
+        && !value.match(/^(ssh|git|svn|svn\+ssh):\/\/(\w+@?)\w+\.\w+.*/)
+        // Eg. git@github.com:foo/bar.git
+        //     github.com:/foo/bar.git
+        && !value.match(/^(\w+@?)\w+\.\w+:.*/)) {
+      return "Not a valid repository URL";
     }
     if (widget == "email" && !validator.isEmail(value)) {
       return "Not a valid email";

--- a/src/test/unit.test.js
+++ b/src/test/unit.test.js
@@ -78,40 +78,124 @@ test('URL test', () => {
   expect(val.checkField('', {
     widget: 'url'
   }, 'hppp://google.it', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'http://google', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'httpz://google.it', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'http:/google.it', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'https:///google.it', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'http//google.it', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'http:/googleit', true))
-    .toBe('Not a valid Url');
+    .toBe('Not a valid URL');
 
   expect(val.checkField('', {
     widget: 'url'
   }, 'https://google.it', true))
+    .toBeNull();
+});
+
+test('repourl validation', () => {
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'hppp://google.it', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'http://google', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'httpz://google.it', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'http:/google.it', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'https:///google.it', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'http//google.it', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'http:/googleit', true))
+    .toBe('Not a valid repository URL');
+
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'https://google.it', true))
+    .toBeNull();
+
+  // Valid git scp-like syntax
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'git@example.com:foobar/baz.git', true))
+    .toBeNull();
+
+  // Invalid syntax, the username is empty
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, '@example.com:foobar/baz.git', true))
+    .toBe('Not a valid repository URL');
+
+  // Valid git:// URL
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'git://example.com/foobar/baz.git', true))
+    .toBeNull();
+
+  // Invalid syntax, the match is not at the beginning
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'junk at beginning git://example.com:foobar/baz.git', true))
+    .toBe('Not a valid repository URL');
+
+  // Valid svn:// URL
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'svn://example.com/foobar/baz/', true))
+    .toBeNull();
+
+  // Valid ssh:// URL
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'ssh://example.com/foobar/baz.git', true))
+    .toBeNull();
+
+  // Valid svn+ssh:// URL
+  expect(val.checkField('', {
+    widget: 'repourl'
+  }, 'svn+ssh://example.com/foobar/baz/', true))
     .toBeNull();
 });


### PR DESCRIPTION
Allow repositories with ssh:// (and its short git form),
git://, svn://, svn+ssh:// as protocol in URL fields, via
a new "repourl" field type.

Also, use https:// as the placeholder for URL fields, to
drop a hint to the user about the nature of such fields.