### PR TITLE
Shrink the header and add an accent color to it.

### DIFF
--- a/src/asset/content.scss
+++ b/src/asset/content.scss
@@ -1,5 +1,6 @@
 $content-pad-horiz: 2em;
-$content-head-h: 120px;
+$content-head-h: 2rem;
+$head-background-color: #fdfdfd;
 
 .field_info {
   span {
@@ -9,17 +10,18 @@ $content-head-h: 120px;
 
 
 .content__head {
-  padding: 0 $content-pad-horiz;
+  padding: 1.5rem $content-pad-horiz 2rem $content-pad-horiz;
   height: $content-head-h;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background: $head-background-color;
 }
 
 .content__head__title {
   color: #0066cc;
   font-family: "Titillium Web";
-  font-size: 52px;
+  font-size: 2rem;
   font-weight: bold;
   letter-spacing: -0.33px;
   line-height: 40px;

--- a/src/asset/language_switcher.scss
+++ b/src/asset/language_switcher.scss
@@ -9,6 +9,7 @@
   margin-bottom: 20px;
   flex-flow: row wrap;
   padding: 0 $content-pad-horiz;
+  background: $head-background-color;
 }
 
 .language-switcher__link,


### PR DESCRIPTION
Shrink the header to leave more space to the actual content and add an
accent color to subtly hint it's a fixed element.

Fix #74.

![Screenshot_2019-11-13 Screenshot](https://user-images.githubusercontent.com/788293/68750484-3c521380-0600-11ea-94c4-3997e1f16b72.png)

What do you think?