### PR TITLE
Show confirmation dialog when removing a language.

### DIFF
--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -272,6 +272,10 @@ class Index extends Component {
   }
 
   removeLang(lng) {
+    if (!confirm(`Are you sure you want to remove '${lng}'?`)) {
+        return;
+    }
+
     //has state
     let { values, languages, currentValues, currentLanguage } = this.state;
     //remove contents of lang


### PR DESCRIPTION
Removing a language is a destructive action: show a confirmation dialog
to the user before taking action.