### PR TITLE
Remove the Reset button.

### DIFF
--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -236,7 +236,6 @@ class Index extends Component {
   renderFoot() {
     //c
     let props = {
-      reset: this.reset.bind(this),
       submitFeedback: this.submitFeedback.bind(this),
       yamlLoaded: this.state.yamlLoaded
     };

--- a/src/app/components/foot.js
+++ b/src/app/components/foot.js
@@ -28,14 +28,6 @@ class foot extends Component {
       <div className="content__foot">
         <div className="content__foot_item">
           <button
-            className="editor_button  editor_button--custom"
-            onClick={() => this.props.reset()}
-          >
-            Reset
-          </button>
-        </div>
-        <div className="content__foot_item">
-          <button
             type="button"
             className="editor_button  editor_button--primary"
 


### PR DESCRIPTION
Pressing the reset button is the most destructive action the user
can take but, despite that

* the expected result when pressed is not clear (clear all the fields
  in the current tab? Remove the current tab? Clear all the tabs? Remove
  all the tabs?)
* it doesn't ask for confirmation
* it's incredibly prominent (right next to the most used button)

Removing the language tabs can still be achieved more intuitively
by pressing the tab's close button.