### PR TITLE
Remove pointer cursor from buttons in sidebar #126

### DIFF
--- a/src/asset/sidebar.scss
+++ b/src/asset/sidebar.scss
@@ -155,7 +155,6 @@
   line-height: 40px;
   flex: 1;
   text-align: center;
-  cursor: pointer;
   a {
     color: #fff;
   }


### PR DESCRIPTION
@libremente I have removed `cursor: pointer;` from the [sidebar.scss](https://github.com/italia/publiccode-editor/blob/master/src/asset/sidebar.scss) file.