### PR TITLE
Editor breaks on license change

### DIFF
--- a/src/app/form/widgets/ComboBoxWidget.js
+++ b/src/app/form/widgets/ComboBoxWidget.js
@@ -22,6 +22,7 @@ const renderInput = field => {
         onBlur={() => field.input.onBlur()}
         value={field.input.value || []}
         data={field.schema.items.enum}
+        onChange={(v)=> field.input.onChange(v.value)}
         valueField='value'
         textField='text'
         filter='contains'


### PR DESCRIPTION
PR #118 introduced a human readable value for Combobox component but the entire object was sent to redux store instead of single value selected.
As for #133 validation breaks the entire Editor since data returned from ext validator was unreadable from editor itself. We should also consider to manage those kind of data, I will track it with a dedicated issue.