### PR TITLE
Always use dependencies versions from yarn.lock.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Stage 0, "build-stage".
 FROM node:lts as build-stage
 WORKDIR /app
-COPY package*.json /app/
+COPY package.json yarn.lock /app/
 
 # First install deps, then copy app and build.
-RUN yarn install
+RUN yarn install --frozen-lockfile
 COPY ./ /app/
 RUN yarn run build-prod
 


### PR DESCRIPTION
Fail if yarn.lock is not up to date in order to allow
reproducible builds.

(needs #135 merged in)