### PR TITLE
Sub-properties are now highlighted when in error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
 orbs:
   slack: circleci/slack@3.4.2
-  publiccode-parser: italia/publiccode-parser@0.0.2
+  publiccode-parser: italia/publiccode-parser@0.0.3
 
 workflows:
   version: 2

--- a/src/app/components/editorForm.js
+++ b/src/app/components/editorForm.js
@@ -116,8 +116,7 @@ const EditForm = props => {
   }
 
   let sectionsWithErrors = [];
-  //submitFailed &&
-
+  
   if (submitFailed && errors) {
     sectionsWithErrors = Object.keys(errors).reduce((s, e) => {
       let field = getFieldByTitle(allFields, e);

--- a/src/app/contents/data.js
+++ b/src/app/contents/data.js
@@ -22,7 +22,18 @@ export const getData = async (countryCode = null) => {
 };
 
 export const getFieldByTitle = (allFields, title) => {
-  return allFields.find(field => field.title === title);
+  // flatten one properties level, see #87
+  const out = allFields.reduce((acc, ele) => {
+    if (ele.properties) {
+      Object.values(ele.properties).forEach(value => {
+        acc.push({ ...ele, title: ele.title + '_' + value.title })
+      });
+    } else {
+      acc.push(ele)
+    }
+    return acc;
+  }, []);
+  return out.find(field => field.title === title);
 };
 
 export const getLabel = (allFields, title) => {

--- a/src/app/contents/data.js
+++ b/src/app/contents/data.js
@@ -26,18 +26,23 @@ export const getFieldByTitle = (allFields, title) => {
   const out = allFields.reduce((acc, ele) => {
     if (ele.properties) {
       Object.values(ele.properties).forEach(value => {
-        acc.push({ ...ele, title: ele.title + '_' + value.title })
+        acc.push({
+            ...ele,
+            title: `${ele.title}_${value.title}`,
+            label: `${ele.label} ${value.label}`
+        })
       });
     } else {
       acc.push(ele)
     }
     return acc;
   }, []);
+
   return out.find(field => field.title === title);
 };
 
 export const getLabel = (allFields, title) => {
-  let field = allFields.find(field => field.title === title);
+  let field = getFieldByTitle(allFields, title);
   if (field) {
     return field.label ? field.label : field.title;
   }


### PR DESCRIPTION
This will highlight also sub-properties in validation process, this is mostly due to divergent ways to call fields between form and go-validator.

It is not ready for merge since exists a bug in parser/external validator:
https://github.com/italia/publiccode-validator/issues/10

Fixes:
#87 