### PR TITLE
Handle remote validator errors.

### DIFF
--- a/src/app/components/sidebar.js
+++ b/src/app/components/sidebar.js
@@ -43,7 +43,7 @@ class sidebar extends Component {
     const funFake = ({
       preventDefault: () => { }
     })
-    
+
     if (remoteYml !== this.props.remoteYml) {
       console.log("remoteYml:", remoteYml);
       this.setState({
@@ -79,8 +79,6 @@ class sidebar extends Component {
       return;
     }
 
-    onReset();
-
     let yaml = null;
     try {
       this.setState({ loading: true });
@@ -98,8 +96,7 @@ class sidebar extends Component {
 
       this.setState({ loading: false });
       this.props.onLoadingRemote(false);
-      console.error(error);
-      this.props.notify({ type: 1, msg: "error parsing remote yaml" });
+      this.props.notify({ type: 1, msg: error.message, millis: 10000 });
     }
   }
 

--- a/src/app/utils/calls.js
+++ b/src/app/utils/calls.js
@@ -8,8 +8,8 @@ export const getReleases = versionsUrl => {
 };
 
 export const passRemoteURLToValidator = yamlURL => {
-  const paramsString = "url=" + yamlURL;
-  // let searchParams = new URLSearchParams(paramsString);
+  const encodedYamlURL = encodeURIComponent(yamlURL);
+  const paramsString = `url=${encodedYamlURL}`;
 
   const myHeaders = new Headers({
     'Accept': 'application/x-yaml',
@@ -22,14 +22,18 @@ export const passRemoteURLToValidator = yamlURL => {
     headers: myHeaders,
     mode: 'cors',
     cache: 'default',
-    // body: searchParams // params are sent in query sting url see below in fetch
   };
 
   if (url == '')
-    return Promise.reject(new Error('no validator url specified'));
+    return Promise.reject(new Error('No validator URL specified'));
 
-  return fetch(url + '?' + paramsString, myInit)
-    .then(res => res.text());
+  return fetch(`${url}?${paramsString}`, myInit)
+    .then(res => {
+      if (! res.ok) {
+        throw new Error(`fetch(${url}) returned ${res.status}`);
+      }
+      res.text()
+    });
 };
 
 export const postDataForValidation = data => {
@@ -48,7 +52,13 @@ export const postDataForValidation = data => {
   };
 
   if (url == '')
-    return Promise.reject(new Error('no validator url specified'));
+    return Promise.reject(new Error('No validator URL specified'));
 
-  return fetch(url, myInit);
+  return fetch(url, myInit)
+    .then(res => {
+      if (! res.ok) {
+        throw new Error(`fetch(${url}) returned ${res.status}`);
+      }
+      res.text()
+    });
 };


### PR DESCRIPTION
Bubble up the validator errors to the user and handle non 2xx responses.

Also don't clean the state before validating, because when the
validation fails the app is left awkwardly empty.