### PR TITLE
Don't try to run CI when pushing to gh-pages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ references:
       name: deploy-gh-pages
       command: |
         echo publiccode-editor.developers.italia.it > dist/CNAME
-        yarn run deploy -- -m "Automated deployment: ${CIRCLE_SHA1}"
+        yarn run deploy -m "Automated deployment: ${CIRCLE_SHA1} [ci skip]"
 
   # In order to use this, the integration needs to be
   # setup first under CircleCI app directory and a


### PR DESCRIPTION
This just removes the noise in the CircleCI app: the pipeline
doesn't start anyway because there's no CircleCI config on
the gh-pages branch.