### PR TITLE
Force the use of literal blocks when dumping the YAML.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "webpack --config webpack.config.js",
     "build-prod": "webpack --config webpack.config.prod.js",
     "test": "jest",
-    "deploy": "gh-pages -u 'Deploy Bot <no-reply@teamdigitale.governo.it>' -d dist"
+    "deploy": "gh-pages -u 'Deploy Bot <no-reply@teamdigitale.governo.it>' -d dist",
+    "postinstall": "patch-package"
   },
   "keywords": [
     "publiccode",
@@ -56,6 +57,7 @@
     "jest": "^23.6.0",
     "node-sass": "^4.13.1",
     "nodemon": "^1.18.10",
+    "patch-package": "^6.2.2",
     "postcss-loader": "^3.0.0",
     "react-test-renderer": "^16.8.6",
     "sass-loader": "^7.1.0",
@@ -80,7 +82,7 @@
     "immutable": "^4.0.0-rc.12",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^3.5.0",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.14.0",
     "lodash": "^4.17.19",
     "mini-css-extract-plugin": "^0.6.0",
     "moment": "^2.24.0",

--- a/patches/js-yaml+3.14.0.patch
+++ b/patches/js-yaml+3.14.0.patch
@@ -1,0 +1,70 @@
+diff --git a/node_modules/js-yaml/lib/js-yaml/dumper.js b/node_modules/js-yaml/lib/js-yaml/dumper.js
+index f3d4fd9..26eee3f 100644
+--- a/node_modules/js-yaml/lib/js-yaml/dumper.js
++++ b/node_modules/js-yaml/lib/js-yaml/dumper.js
+@@ -118,7 +118,7 @@ function State(options) {
+   this.noRefs        = options['noRefs'] || false;
+   this.noCompatMode  = options['noCompatMode'] || false;
+   this.condenseFlow  = options['condenseFlow'] || false;
+-
++  this.forceStyleLiteral = options['forceStyleLiteral'] || false;
+   this.implicitTypes = this.schema.compiledImplicit;
+   this.explicitTypes = this.schema.compiledExplicit;
+ 
+@@ -273,7 +273,7 @@ var STYLE_PLAIN   = 1,
+ //    STYLE_PLAIN or STYLE_SINGLE => no \n are in the string.
+ //    STYLE_LITERAL => no lines are suitable for folding (or lineWidth is -1).
+ //    STYLE_FOLDED => a line > lineWidth and can be folded (and lineWidth != -1).
+-function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType) {
++function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, forceStyleLiteral) {
+   var i;
+   var char, prev_char;
+   var hasLineBreak = false;
+@@ -289,6 +289,9 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
+     for (i = 0; i < string.length; i++) {
+       char = string.charCodeAt(i);
+       if (!isPrintable(char)) {
++        if (forceStyleLiteral) {
++          return STYLE_LITERAL;
++        }
+         return STYLE_DOUBLE;
+       }
+       prev_char = i > 0 ? string.charCodeAt(i - 1) : null;
+@@ -309,6 +312,9 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
+           previousLineBreak = i;
+         }
+       } else if (!isPrintable(char)) {
++        if (forceStyleLiteral) {
++          return STYLE_LITERAL;
++        }
+         return STYLE_DOUBLE;
+       }
+       prev_char = i > 0 ? string.charCodeAt(i - 1) : null;
+@@ -334,6 +340,9 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
+   }
+   // At this point we know block styles are valid.
+   // Prefer literal style unless we want to fold.
++  if (forceStyleLiteral) {
++    return STYLE_LITERAL;
++  }
+   return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+ }
+ 
+@@ -372,14 +381,15 @@ function writeScalar(state, string, level, iskey) {
+       return testImplicitResolving(state, string);
+     }
+ 
+-    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity)) {
++    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity,
++      state.forceStyleLiteral)) {
+       case STYLE_PLAIN:
+         return string;
+       case STYLE_SINGLE:
+         return "'" + string.replace(/'/g, "''") + "'";
+       case STYLE_LITERAL:
+         return '|' + blockHeader(string, state.indent)
+-          + dropEndingNewline(indentString(string, indent));
++          + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
+       case STYLE_FOLDED:
+         return '>' + blockHeader(string, state.indent)
+           + dropEndingNewline(indentString(foldString(string, lineWidth), indent));

--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -8,7 +8,7 @@ import {
   getData,
   SUMMARY
 } from "../contents/data";
-import jsyaml from "../../../node_modules/js-yaml/dist/js-yaml.js";
+import jsyaml from "js-yaml";
 
 import _ from "lodash";
 import moment from "moment";
@@ -183,8 +183,8 @@ class Index extends Component {
   }
 
   /**
-   * 
-   * @param {form data} formValues 
+   *
+   * @param {form data} formValues
    */
   validateAndGenerate(formValues) {
     let lastGen = moment();
@@ -204,7 +204,7 @@ class Index extends Component {
     this.fakeLoading();
     // console.log(obj);
 
-    //  using 
+    //  using
     //  Object.assign(obj, staticFieldsJson)
     //  something weird occur.
     //  needs to investigate further
@@ -308,7 +308,7 @@ class Index extends Component {
     //has state
     try {
       let mergedValue = Object.assign(staticFieldsJson, values);
-      let tmpYaml = jsyaml.dump(mergedValue);
+      let tmpYaml = jsyaml.safeDump(mergedValue, { forceStyleLiteral: true });
       let yaml = staticFieldsYaml + tmpYaml;
       this.setState({ yaml, loading: false });
     } catch (e) {

--- a/src/app/components/index.js
+++ b/src/app/components/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import Schema from "../contents/schema";
 import cleanDeep from "clean-deep";
-import jsyaml from "../../../node_modules/js-yaml/dist/js-yaml.js";
+import jsyaml from "js-yaml";
 import renderField from "../form/renderField";
 import buildSyncValidation from "../form/buildSyncValidation";
 
@@ -164,7 +164,7 @@ class Index extends Component {
     console.log(data);
     //REFORMAT CUSTOM FIELDS DATA
     try {
-      let yaml = jsyaml.dump(data);
+      let yaml = jsyaml.safeDump(data, { forceStyleLiteral: true });
       this.setState({ yaml, error: null });
     } catch (e) {
       console.error(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,6 +284,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -1915,6 +1920,11 @@ ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -3590,6 +3600,14 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -3689,6 +3707,24 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -4571,6 +4607,13 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.5.0"
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -5296,6 +5339,14 @@ js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5452,6 +5503,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^2.0.1:
   version "2.0.2"
@@ -6774,6 +6832,24 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -8250,6 +8326,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Literal blocks allow us to preserve newlines correctly.
Use patch-package to patch js-yaml until a proper solution
reaches upstream.

Fix #51.