### PR TITLE
chore: fix the publiccode validation workflow

### DIFF
--- a/.github/workflows/publiccode-validation.yml
+++ b/.github/workflows/publiccode-validation.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/publiccode-parser-action@v0.0.2-alpha
+    - uses: italia/publiccode-parser-action@v0.0.2-alpha
       with:
         publiccode: 'publiccode.yml'


### PR DESCRIPTION
Use the right GitHub Action name for the publiccode validation workflow.