### PR TITLE
chore: install dependencies from the lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
     run:
       name: install-dependencies
       command: |
-        yarn install
+        yarn install --frozen-lockfile
 
   lint: &lint
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 
   load_image: &load_image
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:12
 
   install_dependencies: &install_dependencies
     run:


### PR DESCRIPTION
Use yarn install --frozen-lockfile to install dependencies from
the lockfile instead of updating it.