### PR TITLE
Default country from env

### DIFF
--- a/src/app/components/editor.js
+++ b/src/app/components/editor.js
@@ -81,8 +81,8 @@ class Index extends Component {
 
   async componentDidMount() {
     await this.initData();
-    this.switchLang("it");
-    this.switchCountry("it");
+    this.switchLang(process.env.DEFAULT_LANG);
+    this.switchCountry(process.env.DEFAULT_COUNTRY);
 
     // checks whether url query parameter
     // is present in url, if so it will

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,9 @@ module.exports = env => {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
           ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
           VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL),
-          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL)
+          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL),
+          DEFAULT_LANG: JSON.stringify(process.env.DEFAULT_LANG || "it"),
+          DEFAULT_COUNTRY: JSON.stringify(process.env.DEFAULT_COUNTRY || "it")
         }
       }),
       new HtmlWebpackPlugin({

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -31,7 +31,9 @@ module.exports = env => {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
           ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
           VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL),
-          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL)
+          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL),
+          DEFAULT_LANG: JSON.stringify(process.env.DEFAULT_LANG || "it"),
+          DEFAULT_COUNTRY: JSON.stringify(process.env.DEFAULT_COUNTRY || "it")
         }
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
I'm working on adopting public code by a large US organization. We will need more changes, this is a basic one.
My ideal approach is to have as much common code as possible and have country or organization customizations as much as possible in config files.

This change simply externalize the default language and country in the config file (.env) instead of being hardcoded in the codebase.

Happy to review/discuss this and other change ideas.