### PR TITLE
Fetch api values

### DIFF
--- a/src/app/contents/fields/generic.js
+++ b/src/app/contents/fields/generic.js
@@ -1,5 +1,5 @@
 import categories from "../categories";
-import scopes from "../scopes";
+import scopes_default from "../scopes";
 import licenses from "../licenses";
 import langs from "../langs";
 import countries from "../countries";
@@ -24,8 +24,23 @@ const softwareType_list = [
 ];
 
 let versions = null;
+let scopes = null;
 
 const fields = async () => {
+  // if provided in .env file, fetch the scopes values from that URL
+  if(process.env.SCOPES_API) {
+    let scopes_api = new Array()
+    let response = await fetch(process.env.SCOPES_API)
+    let json = await response.json()
+    json[0].children.forEach(element => {
+      scopes_api.push(element.text)
+    });
+    console.log("Taxonomy issues", scopes_api)
+    scopes = scopes_api
+  } else {
+    scopes = scopes_default
+  }
+
   if (!versions) {
     // console.log("get versions");
     try {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,8 @@ module.exports = env => {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
           ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
           VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL),
-          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL)
+          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL),
+          SCOPES_API: JSON.stringify(process.env.SCOPES_API)
         }
       }),
       new HtmlWebpackPlugin({

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -31,7 +31,8 @@ module.exports = env => {
           REPOSITORY: JSON.stringify(process.env.REPOSITORY),
           ELASTIC_URL: JSON.stringify(process.env.ELASTIC_URL),
           VALIDATOR_URL: JSON.stringify(process.env.VALIDATOR_URL),
-          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL)
+          VALIDATOR_REMOTE_URL: JSON.stringify(process.env.VALIDATOR_REMOTE_URL),
+          SCOPES_API: JSON.stringify(process.env.SCOPES_API)
         }
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
I'm working on adopting public code by a large US organization. We will need more changes, this is a basic one.
My ideal approach is to have as much common code as possible and have country or organization customizations as much as possible in config files.

This change allows to populate the "Scope" dropdown from a different source, in this case from our Taxonomy API. It is backward compatible, if someone doesn't provide a fetch URL the app will continue to work like it is now.

Happy to review/discuss this and other change ideas.