### PR TITLE
fix: do not overlap label and input elements

### DIFF
--- a/src/asset/style.scss
+++ b/src/asset/style.scss
@@ -1,8 +1,6 @@
 $foot-bar-h: 100px;
 $mq-size: 640px;
 
-@use "bootstrap-italia/src/scss/bootstrap-italia";
-
 // We import CSS here rather than SCSS to avoid an annoying deprecation warning
 // from dart-sass.
 // See https://github.com/jquense/react-widgets/issues/1143.


### PR DESCRIPTION
This is caused by the use of Bootstap Italia.