### PR TITLE
fix: better search in tags widgets

### DIFF
--- a/src/app/form/widgets/TagWidget.js
+++ b/src/app/form/widgets/TagWidget.js
@@ -32,6 +32,7 @@ const TagWidget = (props) => {
         onBlur={() => inputProps.onBlur()}
         value={inputProps.value || []}
         data={props.schema.items.enum}
+        filter="contains"
       />
 
       {invalid && (


### PR DESCRIPTION
Match when the search term is not at the start of the tag as well.

Fix #184.