### PR TITLE
fix: use `innerRef` in design-react-kit `Input` component

### DIFF
--- a/src/app/form/widgets/BaseInputWidget.js
+++ b/src/app/form/widgets/BaseInputWidget.js
@@ -62,7 +62,7 @@ const BaseInputWidget = (props) => {
         validationText={
           invalid ? get(formState.errors, name)?.message : undefined
         }
-        ref={ref}
+        innerRef={ref}
         id={id}
         type={props.type}
         required={props.required}

--- a/src/app/form/widgets/ChoiceExpandedWidget.js
+++ b/src/app/form/widgets/ChoiceExpandedWidget.js
@@ -46,7 +46,7 @@ const ChoiceExpandedWidget = (props) => {
               checked={inputProps.value === value}
               disabled={props.schema.disabled}
               onChange={(e) => inputProps.onChange(e)}
-              ref={ref}
+              innerRef={ref}
             />
             <Label check htmlFor={`${name}-${value}`}>
               {name}


### PR DESCRIPTION
`innerRef` provides a reference to the internal `<input>` element.