### PR TITLE
389 file non supportato

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -13,7 +13,7 @@ cp .devcontainer/githooks/pre-push .git/hooks
 chmod +x .git/hooks/pre-push
 
 echo "Install Global Deps"
-npm i -g http-server
+npm i -g http-server localtunnel
 
 echo "Install Deps"
 npm i

--- a/src/app/yaml-upload.spec.ts
+++ b/src/app/yaml-upload.spec.ts
@@ -28,6 +28,21 @@ describe('yaml upload helper functions tests', () => {
         it('should return false if mime type is application/json', () => {
             testFactory('application/json', false);
         })
+
+        it('should return true if mime type is empty and file is on Windows with .yml extension', () => {
+            jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Windows');
+            testFactory('', true, 'publiccode.yml');
+        })
+
+        it('should return true if mime type is empty and file is on Windows with .yaml extension', () => {
+            jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Windows');
+            testFactory('', true, 'publiccode.yaml');
+        })
+
+        it('should return false if mime type is empty and file is on Windows with a non-YAML extension', () => {
+            jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Windows');
+            testFactory('', false, 'publiccode.json');
+        })
     })
 
     describe('hasYamlFileExtension function tests', () => {

--- a/src/app/yaml-upload.ts
+++ b/src/app/yaml-upload.ts
@@ -4,7 +4,19 @@ const yamlMimeTypes = [
     'text/yaml'
 ]
 
-export const isYamlFile = (file?: File | null) => Boolean(file?.type && yamlMimeTypes.includes(file?.type.toLowerCase()))
+export const isYamlFile = (file?: File | null) => {
+    if (!file) return false;
+
+    if (file.type && yamlMimeTypes.includes(file.type.toLowerCase())) {
+        return true;
+    }
+
+    if (file.type === "" && navigator.userAgent.includes("Windows")) {
+        return file.name.endsWith(".yml") || file.name.endsWith(".yaml");
+    }
+
+    return false;
+};
 
 export const hasYamlFileExtension = (value?: string) => {
     const ext = value?.split(/[. ]+/).pop();

--- a/src/app/yaml-upload.ts
+++ b/src/app/yaml-upload.ts
@@ -7,11 +7,15 @@ const yamlMimeTypes = [
 export const isYamlFile = (file?: File | null) => {
     if (!file) return false;
 
-    if (file.type && yamlMimeTypes.includes(file.type.toLowerCase())) {
+    const hasValidMimeType = file.type && yamlMimeTypes.includes(file.type.toLowerCase());
+
+    if (hasValidMimeType) {
         return true;
     }
 
-    if (file.type === "" && navigator.userAgent.includes("Windows")) {
+    const isRunningOnWindows = file.type === "" && navigator.userAgent.includes("Windows");
+
+    if (isRunningOnWindows) {
         return file.name.endsWith(".yml") || file.name.endsWith(".yaml");
     }
 


### PR DESCRIPTION
### **Fix: YAML / YML File Uploading on Windows**

#### **Tested on:**

- **Operating System:** Windows 11
- **Browsers:** Chrome, Firefox, Edge

#### **Problem:**
On **Windows 11**, when selecting `.yml` or `.yaml` files via the file dialog in a browser, the `file.type` is often empty. This caused issues with proper YAML file recognition, especially when the MIME type isn't automatically detected by the browser.

#### **Solution:**
- **Handling empty MIME types:** We added a check for cases where `file.type` is empty and the user is on Windows. In these cases, we fall back to checking the file extension (either `.yml` or `.yaml`) to determine if the file is a YAML file.
- **Updated `isYamlFile` function:** The logic now correctly handles cases where `file.type` is empty, ensuring proper YAML file recognition on Windows.
- **Improved tests:** We updated and expanded the tests to account for different scenarios, including cases where `file.type` is empty, ensuring correct handling of `.yml` and `.yaml` files. 

#### **Changes:**
- **`isYamlFile` function:** Improved to check the file extension when `file.type` is empty and the user is on Windows.
- **Test updates:**
  - Tests now cover scenarios where `file.type` is empty on Windows, ensuring `.yml` and `.yaml` files are properly recognized.
  - Simulated `navigator.userAgent` for more accurate testing in Windows environments using `jest.spyOn()`. 
- **Devcontainer Update:** Added a command to the devcontainer build to install `localtunnel` globally
