### PR TITLE
fix: remove default language to allow language detection

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -24,7 +24,6 @@ i18n
   .use(initReactI18next)
   .init({
     resources,
-    lng: 'it',
     supportedLngs: Object.keys(resources),
     nonExplicitSupportedLngs: true, // make pass eg. "en-US" if "en" is in supportedLngs
     fallbackLng: FALLBACK_LANGUAGE,


### PR DESCRIPTION
As stated in the [i18next documentation](https://www.i18next.com/overview/configuration-options), setting the `lng` parameter overrides the language detection.
Closes #388 