### PR TITLE
build(deps): bump vite version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@uiw/react-md-editor": "^4.0.5",
         "accessible-autocomplete": "^3.0.1",
-        "axios": "^1.7.9",
+        "axios": "^1.8.2",
         "bootstrap": "^4.6.0",
         "bootstrap-italia": "^2.8.8",
         "copy-to-clipboard": "^3.3.3",
@@ -4553,9 +4553,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3391,7 +3391,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@uiw/react-md-editor": "^4.0.5",
     "accessible-autocomplete": "^3.0.1",
-    "axios": "^1.7.9",
+    "axios": "^1.8.2",
     "bootstrap": "^4.6.0",
     "bootstrap-italia": "^2.8.8",
     "copy-to-clipboard": "^3.3.3",


### PR DESCRIPTION
bump version for the following package:

- @peterek/vite-plugin-favicons
- @vitejs/plugin-react
- tsx
- vite

PR #396 is no longer needed.