### PR TITLE
fix/437: yml version visibility behavior

### DIFF
--- a/src/app/components/Editor.tsx
+++ b/src/app/components/Editor.tsx
@@ -119,13 +119,13 @@ const defaultValues = {
   it: defaultItaly,
 };
 
-const isNotTheLatestVersion = (version1: string, version2: string) => {
+const isNotTheSameVersion = (version1: string, version2: string) => {
   const v1 = toSemVerObject(version1);
   const v2 = toSemVerObject(version2);
   
-  return !(v1.major === v2.major && 
-         v1.minor === v2.minor && 
-         v1.patch === v2.patch);
+  return v1.major !== v2.major || 
+         v1.minor !== v2.minor || 
+         v1.patch !== v2.patch;
 };
 
 export default function Editor() {
@@ -349,7 +349,7 @@ export default function Editor() {
           <form>
             {isPublicCodeImported &&
               publiccodeYmlVersion &&
-              isNotTheLatestVersion(publiccodeYmlVersion, LATEST_VERSION) && (
+              isNotTheSameVersion(publiccodeYmlVersion, LATEST_VERSION) && (
                 <div>
                   <span>
                     <EditorSelect<"publiccodeYmlVersion">

--- a/src/app/components/Editor.tsx
+++ b/src/app/components/Editor.tsx
@@ -119,13 +119,13 @@ const defaultValues = {
   it: defaultItaly,
 };
 
-const areVersionsEquivalent = (version1: string, version2: string) => {
+const isNotTheLatestVersion = (version1: string, version2: string) => {
   const v1 = toSemVerObject(version1);
   const v2 = toSemVerObject(version2);
   
-  return v1.major === v2.major && 
+  return !(v1.major === v2.major && 
          v1.minor === v2.minor && 
-         v1.patch === v2.patch;
+         v1.patch === v2.patch);
 };
 
 export default function Editor() {
@@ -349,7 +349,7 @@ export default function Editor() {
           <form>
             {isPublicCodeImported &&
               publiccodeYmlVersion &&
-              !areVersionsEquivalent(publiccodeYmlVersion, LATEST_VERSION) && (
+              isNotTheLatestVersion(publiccodeYmlVersion, LATEST_VERSION) && (
                 <div>
                   <span>
                     <EditorSelect<"publiccodeYmlVersion">

--- a/src/app/components/Editor.tsx
+++ b/src/app/components/Editor.tsx
@@ -34,6 +34,7 @@ import { useLanguagesStore, useWarningStore, useYamlStore } from "../lib/store";
 import { getYaml } from "../lib/utils";
 import publicCodeAdapter from "../publiccode-adapter";
 import { validator } from "../validator";
+import { toSemVerObject } from "../semver";
 import EditorAwards from "./EditorAwards";
 import EditorBoolean from "./EditorBoolean";
 import EditorContacts from "./EditorContacts";
@@ -116,6 +117,15 @@ const defaultValues = {
   categories: [],
   description: {},
   it: defaultItaly,
+};
+
+const areVersionsEquivalent = (version1: string, version2: string) => {
+  const v1 = toSemVerObject(version1);
+  const v2 = toSemVerObject(version2);
+  
+  return v1.major === v2.major && 
+         v1.minor === v2.minor && 
+         v1.patch === v2.patch;
 };
 
 export default function Editor() {
@@ -339,7 +349,7 @@ export default function Editor() {
           <form>
             {isPublicCodeImported &&
               publiccodeYmlVersion &&
-              publiccodeYmlVersion !== LATEST_VERSION && (
+              !areVersionsEquivalent(publiccodeYmlVersion, LATEST_VERSION) && (
                 <div>
                   <span>
                     <EditorSelect<"publiccodeYmlVersion">


### PR DESCRIPTION
## ✅ What’s been done

The `publiccodeYmlVersion` field is no longer incorrectly displayed when uploading a `publiccode.yml` file with version `0.4`. The issue was caused by a mismatch in version recognition—`0.4` was not being correctly interpreted as equivalent to `0.4.0`. A stricter semantic versioning (semver) check has been implemented to handle this properly.

---

## ✨ Features

Improved version detection with semantic versioning logic.  
Now supports both `0.4` and `0.4.0` as equivalent.

---

## 💥 Breaking changes

No breaking changes introduced.
