### PR TITLE
fix(#450): avoid page reload on info icon click

### DIFF
--- a/src/app/components/EditorScreenshots.tsx
+++ b/src/app/components/EditorScreenshots.tsx
@@ -54,7 +54,11 @@ export default function EditorScreenshots({ lang }: Props): JSX.Element {
           className="description-label active"
           htmlFor={`description.${lang}.screenshots`}
         >{`${label}`}</label>
-        <Button innerRef={buttonRef} className="info-icon-wrapper">
+        <Button
+          type="button"
+          innerRef={buttonRef}
+          className="info-icon-wrapper"
+        >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
         <UncontrolledTooltip placement="bottom" target={buttonRef}>

--- a/src/app/components/EditorUsedBy.tsx
+++ b/src/app/components/EditorUsedBy.tsx
@@ -44,7 +44,11 @@ export default function EditorUsedBy(): JSX.Element {
         <label className="description-label active" htmlFor={`usedby`}>
           {`${label}`}
         </label>
-        <Button innerRef={buttonRef} className="info-icon-wrapper">
+        <Button
+          type="button"
+          innerRef={buttonRef}
+          className="info-icon-wrapper"
+        >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
         <UncontrolledTooltip placement="bottom" target={buttonRef}>

--- a/src/app/components/EditorVideos.tsx
+++ b/src/app/components/EditorVideos.tsx
@@ -129,7 +129,11 @@ export default function EditorVideos({ lang }: Props): JSX.Element {
           className="description-label active"
           htmlFor={`description.${lang}.videos`}
         >{`${label}`}</label>
-        <Button innerRef={buttonRef} className="info-icon-wrapper">
+        <Button
+          type="button"
+          innerRef={buttonRef}
+          className="info-icon-wrapper"
+        >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
         <UncontrolledTooltip placement="bottom" target={buttonRef}>


### PR DESCRIPTION
The issue was caused by missing `type` attribute on the info button: since they default to `submit`, they were unintentionally triggering the form submission.

Closes #450 