### PR TITLE
chore: tell dependabot to check go deps as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/src/wasm"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Tell dependabot to check go deps as well, this should keep publiccode-parser-go updated, which is a very important thing to do.

I'm not sure it's the right syntax, but let's try and see.