### PR TITLE
fix/512: reset validation on import

### DIFF
--- a/src/app/components/Editor.tsx
+++ b/src/app/components/Editor.tsx
@@ -349,6 +349,7 @@ export default function Editor() {
   };
 
   const loadFileYamlHandler = async (file: File) => {
+    resetFormHandler();
     const fetchDataFn = () => fileImporter(file);
 
     await setFormDataAfterImport(fetchDataFn);
@@ -358,6 +359,7 @@ export default function Editor() {
     url: string;
     source: "gitlab" | "other";
   }) => {
+    resetFormHandler();
     try {
       console.log("loadRemoteYamlHandler", event);
       const fetchDataFn =


### PR DESCRIPTION
## ✅ What's been done

Fixed a critical bug where loading an invalid YAML file after a valid one would silently keep the previous valid data and show misleading "Validation completed with success" message.

---

## ✨ Features

- **Fixed Import State Management**: Editor now properly clears previous form data before attempting to load a new file

---

## 💥 Breaking changes

No breaking changes introduced. This is a bug fix that improves existing functionality.


