### PR TITLE
fix(ui) #539: update unknown fields behavior

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -53,7 +53,7 @@
         "notification_title": "Validierungsfehler",
         "notification_text": "Überprüfen Sie die Felder des Formulars",
         "info": {
-          "title": "Unbekannte Felder entfernt"
+          "title": "Automatische Korrekturen auf die folgenden Felder angewendet"
         },
         "button": "Validieren"
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -68,7 +68,7 @@
           "text": "Check form fields"
         },
         "info": {
-          "title": "Unknown fields removed"
+          "title": "Automatic corrections applied to the following fields"
         },
         "button": "Validate"
       },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -68,7 +68,7 @@
           "text": "Check form fields"
         },
         "info": {
-          "title": "Champs inconnus supprimés"
+          "title": "Corrections automatiques appliquées aux champs suivants"
         },
         "button": "Validate"
       },

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -69,7 +69,7 @@
           "text": "Controlla i campi della form"
         },
         "info": {
-          "title": "Campi sconosciuti rimossi"
+          "title": "Correzioni automatiche applicate sui seguenti campi"
         },
         "button": "Valida"
       },

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -68,7 +68,7 @@
           "text": "Controleer formuliervelden"
         },
         "info": {
-          "title": "Onbekende velden verwijderd"
+          "title": "Automatische correcties toegepast op de volgende velden"
         },
         "button": "Valideren"
       },


### PR DESCRIPTION
✅ What’s been done

Improved handling of unknown fields during publiccode.yml import. Unknown fields removed by the linter are now surfaced as validation warnings under an “Automatic corrections applied to the following fields” info message, with aligned copy across all supported locales.

<img width="758" height="172" alt="Screenshot 2025-11-19 alle 10 52 31" src="https://github.com/user-attachments/assets/cc55587c-fef9-4411-8b54-a58d046c2258" />
