### PR TITLE
Clarified "addlanguage" (de, en, fr, it)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -15,7 +15,7 @@
     "needhelp": "Brauchen Sie Hilfe?",
     "source_code": "Quellcode",
     "lastgeneration": "Letzte Generierung",
-    "addlanguage": "Sprache zur publiccode.yml-Datei hinzufügen...",
+    "addlanguage": "\"Beschreibung und Funktionen\" in weiterer Sprache hinzufügen...",
     "nocodegenerated": "Kein Code generiert",
     "copy": "Kopieren",
     "copytext": "In die Zwischenablage kopiert",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -24,7 +24,7 @@
     "needhelp": "Need Help?",
     "source_code": "Source code",
     "lastgeneration": "Last generation",
-    "addlanguage": "add language to the publiccode.yml file...",
+    "addlanguage": "\"Description and features\" add in another language...",
     "nocodegenerated": "No code generated",
     "copy": "Copy to clipboard",
     "copytext": "Copied to clipboard",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -24,7 +24,7 @@
     "needhelp": "Need Help?",
     "source_code": "Source code",
     "lastgeneration": "Last generation",
-    "addlanguage": "add language to the publiccode.yml file...",
+    "addlanguage": "\"Description et fonctionnalités\" ajouter dans une autre langue...",
     "nocodegenerated": "No code generated",
     "copy": "Copy to clipboard",
     "copytext": "Copied to clipboard",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -25,7 +25,7 @@
     "needhelp": "Aiuto?",
     "source_code": "Codice sorgente",
     "lastgeneration": "Ultimo aggiornamento",
-    "addlanguage": "aggiungi lingua al file publiccode.yml...",
+    "addlanguage": "\"Descrizione e funzioni\" aggiungi in un’altra lingua...",
     "nocodegenerated": "Nessun publiccode generato",
     "copy": "Copia",
     "copytext": "Copiato negli appunti",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -24,7 +24,7 @@
     "needhelp": "Hulp nodig?",
     "source_code": "Broncode",
     "lastgeneration": "Laatste generatie",
-    "addlanguage": "taal toevoegen aan het publiccode.yml bestand...",
+    "addlanguage": "\"Beschrijving en functies\" in een andere taal toevoegen...",
     "nocodegenerated": "Geen code gegenereerd",
     "copy": "Kopiëren naar klembord",
     "copytext": "Gekopieerd naar klembord",


### PR DESCRIPTION
Made it clear this refers to an additional description language, not the app language. Removed the explicit mention of publiccode.yml as it’s already implied.

PS: Spero che qui valga: ogni poco aiuta. Greetings from germany.
