### PR TITLE
fix/557: set uri mandatory and name optional

### DIFF
--- a/src/app/components/Editor.tsx
+++ b/src/app/components/Editor.tsx
@@ -579,7 +579,10 @@ export default function Editor() {
                 <EditorInput<"isBasedOn"> fieldName="isBasedOn" />
               </span>
               <span>
-                <EditorInput<"organisation.uri"> fieldName="organisation.uri" />
+                <EditorInput<"organisation.uri"> fieldName="organisation.uri" required />
+              </span>
+              <span>
+                <EditorInput<"organisation.name"> fieldName="organisation.name" />
               </span>
               <div className="mt-4 mb-4">
                 <EditorFundedBy />

--- a/src/app/contents/publiccode.ts
+++ b/src/app/contents/publiccode.ts
@@ -216,6 +216,7 @@ export const publicCodeDummyObjectFactory = () =>
 
 export interface Organisation {
   uri: string;
+  name?: string;
 }
 
 export type { Organisation as TOrganisation };

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -363,7 +363,11 @@
     "organisation": {
       "uri": {
         "label": "Organisations-URI",
-        "description": "Eine eindeutige Kennung für die Organisation, die die Software entwickelt, wartet oder besitzt. Es kann eine standardmäßige URI oder ein URN sein (z. B. urn:x-italian-pa:[codiceIPA] für italienische öffentliche Verwaltungen)."
+        "description": "Eine eindeutige Kennung für die Organisation, die die Software entwickelt, wartet oder besitzt. Es kann eine standardmäßige URI oder ein URN sein (z. B. urn:x-italian-pa:[codiceIPA] für italienische öffentliche Verwaltungen). Pflichtfeld."
+      },
+      "name": {
+        "label": "Name der Organisation",
+        "description": "Der kanonische Name der Organisation, die die Software veröffentlicht. Optional."
       }
     },
     "fundedBy": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -379,7 +379,11 @@
     "organisation": {
       "uri": {
         "label": "Organisation URI",
-        "description": "A unique identifier for the organisation that develops, maintains or owns the software. It can be a standard URI or a URN (e.g., urn:x-italian-pa:[codiceIPA] for Italian public administrations)."
+        "description": "A unique identifier for the organisation that develops, maintains or owns the software. It can be a standard URI or a URN (e.g., urn:x-italian-pa:[codiceIPA] for Italian public administrations). Mandatory."
+      },
+      "name": {
+        "label": "Organisation name",
+        "description": "The canonical name of the organisation publishing the software. Optional."
       }
     },
     "fundedBy": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -376,7 +376,11 @@
     "organisation": {
       "uri": {
         "label": "URI de l'organisation",
-        "description": "Un identifiant unique pour l'organisation qui développe, maintient ou possède le logiciel. Il peut s'agir d'un URI standard ou d'un URN (par exemple, urn:x-italian-pa:[codiceIPA] pour les administrations publiques italiennes)."
+        "description": "Un identifiant unique pour l'organisation qui développe, maintient ou possède le logiciel. Il peut s'agir d'un URI standard ou d'un URN (par exemple, urn:x-italian-pa:[codiceIPA] pour les administrations publiques italiennes). Obligatoire."
+      },
+      "name": {
+        "label": "Nom de l'organisation",
+        "description": "Le nom canonique de l'organisation qui publie le logiciel. Optionnel."
       }
     },
     "fundedBy": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -380,7 +380,11 @@
     "organisation": {
       "uri": {
         "label": "URI organizzazione",
-        "description": "Un identificatore univoco per l'organizzazione che sviluppa, mantiene o possiede il software. Può essere un URI standard o un URN (ad esempio, urn:x-italian-pa:[codiceIPA] per le amministrazioni pubbliche italiane)."
+        "description": "Un identificatore univoco per l'organizzazione che sviluppa, mantiene o possiede il software. Può essere un URI standard o un URN (ad esempio, urn:x-italian-pa:[codiceIPA] per le amministrazioni pubbliche italiane). Obbligatorio."
+      },
+      "name": {
+        "label": "Nome organizzazione",
+        "description": "Il nome canonico dell'organizzazione che pubblica il software. Opzionale."
       }
     },
     "fundedBy": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -379,7 +379,11 @@
     "organisation": {
       "uri": {
         "label": "Organisatie-URI",
-        "description": "Een unieke identifier voor de organisatie die de software ontwikkelt, onderhoudt of bezit. Het kan een standaard URI of een URN zijn (bijv. urn:x-italian-pa:[codiceIPA] voor Italiaanse openbare besturen)."
+        "description": "Een unieke identifier voor de organisatie die de software ontwikkelt, onderhoudt of bezit. Het kan een standaard URI of een URN zijn (bijv. urn:x-italian-pa:[codiceIPA] voor Italiaanse openbare besturen). Verplicht."
+      },
+      "name": {
+        "label": "Naam organisatie",
+        "description": "De canonieke naam van de organisatie die de software uitgeeft. Optioneel."
       }
     },
     "fundedBy": {


### PR DESCRIPTION
Fixes #557

### ✅ What's been done

**Problem**: The organisation section was not aligned with the schema: organisation/uri is mandatory and organisation/name is optional, but the editor did not reflect this.

**Done**: 

- Organisation type updated so uri is required and name is optional;
- In the form, organisation.uri is marked as required and organisation.name is added as an optional field;
- Copy in EN, IT, FR, DE, NL updated so URI is described as mandatory and name as optional.
