### PR TITLE
fix: resolve accessibility issues from FastPass audit

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -70,9 +70,13 @@ export const App = () => {
               </div>
             ) : (
               <PanelGroup direction="horizontal">
-                <Panel defaultSize={100}>{leftPanel}</Panel>
+                <Panel id="editor-panel" defaultSize={100}>
+                  {leftPanel}
+                </Panel>
                 <PanelResizeHandle className="panel-resize-handle" />
-                <Panel defaultSize={80}>{rightPanel}</Panel>
+                <Panel id="preview-panel" defaultSize={80}>
+                  {rightPanel}
+                </Panel>
               </PanelGroup>
             )}
           </div>

--- a/src/app/components/AccessibleMultiselectTagList.tsx
+++ b/src/app/components/AccessibleMultiselectTagList.tsx
@@ -1,0 +1,60 @@
+import type { MultiselectTagListProps } from "react-widgets/cjs/MultiselectTagList";
+
+/**
+ * Custom `tagListComponent` for react-widgets `<Multiselect>`.
+ *
+ * The library's default tag list wraps the combobox `<input>` inside a
+ * `role="listbox"` and renders each selected tag as a `role="option"` that
+ * contains a remove `<button>`. That markup produces two axe failures:
+ *
+ *   - `aria-required-children`: a `listbox` may only contain `option`/`group`
+ *     children, not the nested `combobox` input.
+ *   - `nested-interactive`: an interactive control (the remove `<button>`) is
+ *     nested inside another interactive element (the `option`).
+ *
+ * Here we render the tags as plain elements (no `listbox`/`option` roles) with
+ * a real, focusable, labelled remove button. The container keeps `id` so the
+ * input's `aria-owns` reference still resolves. react-widgets keeps handling
+ * keyboard removal (Backspace/Delete) at the input level.
+ */
+export default function AccessibleMultiselectTagList<TDataItem>({
+  id,
+  value,
+  textAccessor,
+  disabled,
+  readOnly,
+  onDelete,
+  children,
+  clearTagIcon,
+  renderTagValue,
+}: MultiselectTagListProps<TDataItem>): JSX.Element {
+  return (
+    <div id={id} className="rw-multiselect-taglist">
+      {value.map((item, i) => {
+        const itemDisabled = Array.isArray(disabled)
+          ? disabled.includes(item)
+          : Boolean(disabled);
+        const text = textAccessor(item);
+        return (
+          <div key={i} className="rw-multiselect-tag">
+            <span className="rw-multiselect-tag-label">
+              {renderTagValue ? renderTagValue({ item }) : text}
+            </span>
+            <button
+              type="button"
+              className="rw-multiselect-tag-btn"
+              aria-label={`Remove ${text}`}
+              disabled={itemDisabled || readOnly}
+              onClick={(event) => {
+                if (!itemDisabled && !readOnly) onDelete(item, event);
+              }}
+            >
+              {clearTagIcon}
+            </button>
+          </div>
+        );
+      })}
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/AccessibleMultiselectTagList.tsx
+++ b/src/app/components/AccessibleMultiselectTagList.tsx
@@ -1,7 +1,8 @@
+import type { ComponentType, MouseEvent } from "react";
 import type { MultiselectTagListProps } from "react-widgets/cjs/MultiselectTagList";
 
 /**
- * Custom `tagListComponent` for react-widgets `<Multiselect>`.
+ * Builds a custom `tagListComponent` for react-widgets `<Multiselect>`.
  *
  * The library's default tag list wraps the combobox `<input>` inside a
  * `role="listbox"` and renders each selected tag as a `role="option"` that
@@ -12,49 +13,72 @@ import type { MultiselectTagListProps } from "react-widgets/cjs/MultiselectTagLi
  *   - `nested-interactive`: an interactive control (the remove `<button>`) is
  *     nested inside another interactive element (the `option`).
  *
- * Here we render the tags as plain elements (no `listbox`/`option` roles) with
- * a real, focusable, labelled remove button. The container keeps `id` so the
- * input's `aria-owns` reference still resolves. react-widgets keeps handling
- * keyboard removal (Backspace/Delete) at the input level.
+ * We drop the `listbox`/`option` roles entirely and render plain elements with
+ * a labelled remove button. Removal does NOT go through react-widgets'
+ * `onDelete` (its `handleDelete` bails out unless the tag is registered in the
+ * widget's internal focus list, which we can't reliably do from app code);
+ * instead it calls the `onRemove` callback supplied here, which updates the
+ * controlled value directly. The container keeps `id` so the input's
+ * `aria-owns` reference still resolves.
  */
-export default function AccessibleMultiselectTagList<TDataItem>({
-  id,
-  value,
-  textAccessor,
-  disabled,
-  readOnly,
-  onDelete,
-  children,
-  clearTagIcon,
-  renderTagValue,
-}: MultiselectTagListProps<TDataItem>): JSX.Element {
-  return (
-    <div id={id} className="rw-multiselect-taglist">
-      {value.map((item, i) => {
-        const itemDisabled = Array.isArray(disabled)
-          ? disabled.includes(item)
-          : Boolean(disabled);
-        const text = textAccessor(item);
-        return (
-          <div key={i} className="rw-multiselect-tag">
-            <span className="rw-multiselect-tag-label">
-              {renderTagValue ? renderTagValue({ item }) : text}
-            </span>
-            <button
-              type="button"
-              className="rw-multiselect-tag-btn"
-              aria-label={`Remove ${text}`}
-              disabled={itemDisabled || readOnly}
-              onClick={(event) => {
-                if (!itemDisabled && !readOnly) onDelete(item, event);
-              }}
-            >
-              {clearTagIcon}
-            </button>
-          </div>
-        );
-      })}
-      {children}
-    </div>
-  );
+export function createAccessibleMultiselectTagList<TDataItem>(
+  onRemove: (item: TDataItem) => void,
+): ComponentType<MultiselectTagListProps<unknown>> {
+  function AccessibleMultiselectTagList({
+    id,
+    value,
+    textAccessor,
+    disabled,
+    readOnly,
+    children,
+    clearTagIcon,
+    renderTagValue,
+  }: MultiselectTagListProps<TDataItem>): JSX.Element {
+    return (
+      <div id={id} className="rw-multiselect-taglist">
+        {value.map((item, i) => {
+          const itemDisabled = Array.isArray(disabled)
+            ? disabled.includes(item)
+            : Boolean(disabled);
+
+          const remove = (event: MouseEvent<HTMLButtonElement>) => {
+            // Run before the widget's own click/focus handling and don't let
+            // the click bubble up to open the dropdown.
+            event.preventDefault();
+            event.stopPropagation();
+            if (!itemDisabled && !readOnly) onRemove(item);
+          };
+
+          return (
+            <div key={i} className="rw-multiselect-tag">
+              <span className="rw-multiselect-tag-label">
+                {renderTagValue ? renderTagValue({ item }) : textAccessor(item)}
+              </span>
+              <button
+                type="button"
+                className="rw-multiselect-tag-btn"
+                aria-label={`Remove ${textAccessor(item)}`}
+                disabled={itemDisabled || readOnly}
+                onMouseDown={remove}
+                onClick={(event) => {
+                  if (event.detail === 0) remove(event); // keyboard (Enter/Space)
+                }}
+              >
+                {clearTagIcon}
+              </button>
+            </div>
+          );
+        })}
+        {children}
+      </div>
+    );
+  }
+
+  // react-widgets types `tagListComponent` as `ComponentType<…<unknown>>`
+  // (and the attached propTypes make it invariant), so a component typed for a
+  // concrete item type isn't directly assignable. The cast is safe: react-widgets
+  // only ever hands us items of the type the surrounding <Multiselect> uses.
+  return AccessibleMultiselectTagList as unknown as ComponentType<
+    MultiselectTagListProps<unknown>
+  >;
 }

--- a/src/app/components/EditorAwards.tsx
+++ b/src/app/components/EditorAwards.tsx
@@ -79,6 +79,7 @@ export default function EditorAwards({ lang }: Props): JSX.Element {
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -107,6 +108,7 @@ export default function EditorAwards({ lang }: Props): JSX.Element {
         <InputGroup>
           <Input
             {...field}
+            id={`description.${lang}.awards`}
             type="text"
             value={current}
             onChange={({ target }) => setCurrent(target.value)}

--- a/src/app/components/EditorContacts.tsx
+++ b/src/app/components/EditorContacts.tsx
@@ -47,6 +47,9 @@ export default function EditorContacts(): JSX.Element {
             type="button"
             innerRef={buttonRef}
             className="info-icon-wrapper"
+            aria-label={`${t("editor.form.moreInfo")}: ${t(
+              `publiccodeyml.${fieldName}.label`
+            )}`}
           >
             <Icon icon="it-info-circle" className="info-icon mb-2" />
           </Button>
@@ -108,6 +111,9 @@ export default function EditorContacts(): JSX.Element {
                           {...reg}
                           onChange={debouncedOnChangeRef.current[fieldKey]}
                           label={true}
+                          aria-label={t(
+                            `publiccodeyml.${fieldName}.${subfield}.label`
+                          )}
                           innerRef={ref}
                           valid={
                             get(errors, `${fieldName}.${index}.${subfield}`) &&

--- a/src/app/components/EditorDate.tsx
+++ b/src/app/components/EditorDate.tsx
@@ -42,6 +42,7 @@ export default function EditorDate<
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -50,6 +51,7 @@ export default function EditorDate<
         </UncontrolledTooltip>
       </div>
       <Input
+        id={name}
         onBlur={onBlur}
         onChange={onChange}
         name={name}

--- a/src/app/components/EditorDescriptionInput.tsx
+++ b/src/app/components/EditorDescriptionInput.tsx
@@ -61,7 +61,7 @@ export default function EditorInput<
     <div>
       <div>
         <div className="position-relative mb-2">
-          <label className="description-label active">
+          <label className="description-label active" htmlFor={name}>
             {`${label}${extraLangInfo}${required ? " *" : ""}${
               deprecated ? ` - ${t(`editor.form.deprecatedField`)}` : ""
             }`}
@@ -70,6 +70,7 @@ export default function EditorInput<
             type="button"
             innerRef={buttonRef}
             className="info-icon-wrapper"
+            aria-label={`${t("editor.form.moreInfo")}: ${label}`}
           >
             <Icon icon="it-info-circle" className="info-icon" />
           </Button>
@@ -78,6 +79,7 @@ export default function EditorInput<
           </UncontrolledTooltip>
         </div>
         <Tag
+          id={name}
           onBlur={onBlur}
           onChange={({ target: { value } }) => onChange(value)}
           name={name}

--- a/src/app/components/EditorFeatures.tsx
+++ b/src/app/components/EditorFeatures.tsx
@@ -78,6 +78,7 @@ export default function EditorFeatures({ lang }: Props): JSX.Element {
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -106,6 +107,7 @@ export default function EditorFeatures({ lang }: Props): JSX.Element {
         <InputGroup>
           <Input
             {...field}
+            id={`description.${lang}.features`}
             value={current}
             onChange={({ target }) => setCurrent(target.value)}
             innerRef={inputRef}

--- a/src/app/components/EditorInput.tsx
+++ b/src/app/components/EditorInput.tsx
@@ -49,7 +49,7 @@ export default function EditorInput<
   return (
     <div>
       <div className="position-relative">
-        <label className="description-label active">
+        <label className="description-label active" htmlFor={name}>
           {`${label}${required ? " *" : ""}${
             deprecated ? ` - ${t(`editor.form.deprecatedField`)}` : ""
           }`}
@@ -58,6 +58,7 @@ export default function EditorInput<
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon" />
         </Button>
@@ -66,6 +67,7 @@ export default function EditorInput<
         </UncontrolledTooltip>
       </div>
       <Tag
+        id={name}
         onBlur={onBlur}
         onChange={onChange}
         name={name}

--- a/src/app/components/EditorMDInput.tsx
+++ b/src/app/components/EditorMDInput.tsx
@@ -68,6 +68,7 @@ export default function EditorInput<
             type="button"
             innerRef={buttonRef}
             className="info-icon-wrapper"
+            aria-label={`${t("editor.form.moreInfo")}: ${label}`}
           >
             <Icon icon="it-info-circle" className="info-icon" />
           </Button>

--- a/src/app/components/EditorMultiselect.tsx
+++ b/src/app/components/EditorMultiselect.tsx
@@ -1,5 +1,5 @@
 import { get } from "lodash";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   FieldPathByValue,
   useController,
@@ -14,7 +14,7 @@ import PublicCode, {
 } from "../contents/publiccode";
 import flattenObject from "../flatten-object-to-record";
 import { Button, Icon, UncontrolledTooltip } from "design-react-kit";
-import AccessibleMultiselectTagList from "./AccessibleMultiselectTagList";
+import { createAccessibleMultiselectTagList } from "./AccessibleMultiselectTagList";
 
 type Props<T> = {
   fieldName: T;
@@ -80,6 +80,20 @@ export default function EditorMultiselect<
     }
   }, [errors, fieldName, inputRef]);
 
+  // Keep a ref to the latest value so the (stable) tag list can remove items
+  // without being recreated on every change (which would remount the input and
+  // steal focus).
+  const filteredValueRef = useRef(filteredValue);
+  filteredValueRef.current = filteredValue;
+  const TagList = useMemo(
+    () =>
+      createAccessibleMultiselectTagList<{ value: string; text: string }>(
+        (item) =>
+          onChange(filteredValueRef.current.filter((v) => v !== item.value)),
+      ),
+    [onChange],
+  );
+
   return (
     <div>
       <div className="position-relative mb-2">
@@ -112,7 +126,7 @@ export default function EditorMultiselect<
           filter={filter}
           ref={inputRef}
           inputProps={{ "aria-label": label }}
-          tagListComponent={AccessibleMultiselectTagList}
+          tagListComponent={TagList}
         />
 
         {errorMessage && (

--- a/src/app/components/EditorMultiselect.tsx
+++ b/src/app/components/EditorMultiselect.tsx
@@ -14,6 +14,7 @@ import PublicCode, {
 } from "../contents/publiccode";
 import flattenObject from "../flatten-object-to-record";
 import { Button, Icon, UncontrolledTooltip } from "design-react-kit";
+import AccessibleMultiselectTagList from "./AccessibleMultiselectTagList";
 
 type Props<T> = {
   fieldName: T;
@@ -91,6 +92,7 @@ export default function EditorMultiselect<
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -109,6 +111,8 @@ export default function EditorMultiselect<
           textField="text"
           filter={filter}
           ref={inputRef}
+          inputProps={{ "aria-label": label }}
+          tagListComponent={AccessibleMultiselectTagList}
         />
 
         {errorMessage && (

--- a/src/app/components/EditorScreenshots.tsx
+++ b/src/app/components/EditorScreenshots.tsx
@@ -60,6 +60,7 @@ export default function EditorScreenshots({ lang }: Props): JSX.Element {
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -116,6 +117,7 @@ export default function EditorScreenshots({ lang }: Props): JSX.Element {
         )}
         <InputGroup>
           <Input
+            id={`description.${lang}.screenshots`}
             value={current}
             onChange={({ target }) => setCurrent(target.value)}
             onKeyDown={(e) => {

--- a/src/app/components/EditorSelect.tsx
+++ b/src/app/components/EditorSelect.tsx
@@ -52,6 +52,7 @@ export default function EditorSelect<
         dataKey="value"
         textField="text"
         filter={filter}
+        inputProps={{ "aria-label": label }}
       />
       <small className="form-text">{description}</small>
       {errorMessage && (

--- a/src/app/components/EditorUsedBy.tsx
+++ b/src/app/components/EditorUsedBy.tsx
@@ -48,6 +48,7 @@ export default function EditorUsedBy(): JSX.Element {
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -71,6 +72,7 @@ export default function EditorUsedBy(): JSX.Element {
         </ul>
         <InputGroup>
           <Input
+            id={`usedby`}
             value={current}
             onChange={({ target }) => setCurrent(target.value)}
             onKeyDown={(e) => {

--- a/src/app/components/EditorVideos.tsx
+++ b/src/app/components/EditorVideos.tsx
@@ -140,6 +140,7 @@ export default function EditorVideos({ lang }: Props): JSX.Element {
           type="button"
           innerRef={buttonRef}
           className="info-icon-wrapper"
+          aria-label={`${t("editor.form.moreInfo")}: ${label}`}
         >
           <Icon icon="it-info-circle" className="info-icon mb-2" />
         </Button>
@@ -201,6 +202,7 @@ export default function EditorVideos({ lang }: Props): JSX.Element {
         )}
         <InputGroup>
           <Input
+            id={`description.${lang}.videos`}
             type="text"
             value={current}
             onChange={({ target }) => {

--- a/src/app/components/Head.tsx
+++ b/src/app/components/Head.tsx
@@ -58,6 +58,7 @@ const Head = ({
                 size="sm"
                 className="ms-4"
                 icon
+                aria-label={t("editor.settings.title")}
                 onClick={() => onSettingsClick()}
               >
                 <Icon color="white" size="sm" icon="it-settings" />

--- a/src/app/components/PubliccodeYmlLanguages.tsx
+++ b/src/app/components/PubliccodeYmlLanguages.tsx
@@ -1,10 +1,11 @@
 import { upperFirst } from "lodash";
+import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Multiselect } from "react-widgets";
 import { RenderItemProp } from "react-widgets/cjs/List";
 import { allLangs } from "../../i18n";
 import { useLanguagesStore } from "../lib/store";
-import AccessibleMultiselectTagList from "./AccessibleMultiselectTagList";
+import { createAccessibleMultiselectTagList } from "./AccessibleMultiselectTagList";
 
 interface Language {
   value: string;
@@ -27,6 +28,20 @@ export const PubliccodeYmlLanguages = (): JSX.Element => {
     }
   };
 
+  // Stable tag list; reads the latest languages via a ref so its identity does
+  // not change (which would remount the input and steal focus). Keeps the
+  // "don't remove the last language" guard.
+  const languagesRef = useRef(languages);
+  languagesRef.current = languages;
+  const TagList = useMemo(
+    () =>
+      createAccessibleMultiselectTagList<Language>((item) => {
+        const next = languagesRef.current.filter((v) => v !== item.value);
+        if (next.length) setLanguages(next);
+      }),
+    [setLanguages],
+  );
+
   return (
     <div className="language-switcher">
       <Multiselect
@@ -40,7 +55,7 @@ export const PubliccodeYmlLanguages = (): JSX.Element => {
         renderListItem={renderListItem as RenderItemProp<Language>} //wa for tsc
         renderTagValue={renderTagValue}
         value={languages}
-        tagListComponent={AccessibleMultiselectTagList}
+        tagListComponent={TagList}
       />
     </div>
   );

--- a/src/app/components/PubliccodeYmlLanguages.tsx
+++ b/src/app/components/PubliccodeYmlLanguages.tsx
@@ -4,6 +4,7 @@ import { Multiselect } from "react-widgets";
 import { RenderItemProp } from "react-widgets/cjs/List";
 import { allLangs } from "../../i18n";
 import { useLanguagesStore } from "../lib/store";
+import AccessibleMultiselectTagList from "./AccessibleMultiselectTagList";
 
 interface Language {
   value: string;
@@ -39,6 +40,7 @@ export const PubliccodeYmlLanguages = (): JSX.Element => {
         renderListItem={renderListItem as RenderItemProp<Language>} //wa for tsc
         renderTagValue={renderTagValue}
         value={languages}
+        tagListComponent={AccessibleMultiselectTagList}
       />
     </div>
   );

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -924,9 +924,8 @@ SETTINGS
 .preview__info {
   font-size: 14px;
   line-height: 28px;
-  color: #fff;
+  color: #6e94bb;
   margin-left: 20px;
-  opacity: 0.3;
 }
 
 .preview__prefooter {
@@ -1053,6 +1052,7 @@ SETTINGS
   margin-left: 2px;
   line-height: 24px;
   font-size: 16px;
+  color: #fff;
 }
 
 .preview__footer_item img {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -41,6 +41,7 @@
     },
     "form": {
       "add": "Hinzufügen",
+      "moreInfo": "Weitere Informationen",
       "deprecatedField": "Veraltet",
       "noContacts": "Keine Kontakte vorhanden",
       "noContractors": "Keine Auftragnehmer vorhanden",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -50,6 +50,7 @@
     },
     "form": {
       "add": "Add",
+      "moreInfo": "More information",
       "deprecatedField": "deprecated",
       "noContractors": "No contractors present",
       "noContacts": "No contacts present",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -50,6 +50,7 @@
     },
     "form": {
       "add": "Ajouter",
+      "moreInfo": "Plus d'informations",
       "deprecatedField": "deprecated",
       "noContractors": "Aucun référent présent",
       "noContacts": "Aucun contact présent",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -51,6 +51,7 @@
     },
     "form": {
       "add": "Aggiungi",
+      "moreInfo": "Maggiori informazioni",
       "deprecatedField": "deprecated",
       "noContacts": "Nessun contatto presente",
       "noContractors": "Nessun riferimento presente",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -50,6 +50,7 @@
     },
     "form": {
       "add": "Toevoegen",
+      "moreInfo": "Meer informatie",
       "deprecatedField": "verouderd",
       "noContractors": "Geen aannemers gevonden",
       "noContacts": "Geen contacten gevonden",


### PR DESCRIPTION
Closes #619

Resolves all 57 accessibility issues from the Accessibility Insights FastPass audit:

- **button-name (24):** `aria-label` on the info-icon buttons across the `Editor*` components and on the header settings button
- **label (24):** form controls associated with their labels via `id`/`htmlFor`; `aria-label` on the react-widgets Combobox/Multiselect inputs and on the contacts table inputs
- **color-contrast (3):** `.preview__info` and `.preview__footer .action` colors adjusted to meet the 4.5:1 ratio
- **aria-valid-attr-value (1):** explicit `id`s on the panels so the resize handle `aria-controls` references a real element
- **aria-required-children (4) + nested-interactive (1):** custom `AccessibleMultiselectTagList` (`tagListComponent`) so the combobox input is no longer a child of the `listbox` and the remove control is no longer nested inside an `option`
