### PR TITLE
build: remove package.json imports

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./app/App.tsx";
-import packageJson from "../package.json";
 
-console.log(`${packageJson.name} ${packageJson.version}`);
+console.log(`${__APP_NAME__} ${__APP_VERSION__}`);
 
 createRoot(document.getElementById("app")!).render(<App />);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./app/App.tsx";
 
-console.log(`${__APP_NAME__} ${__APP_VERSION__}`);
+console.log(`${__APP_NAME__} ${__APP_VERSION__} (${__APP_COMMIT__})`);
 
 createRoot(document.getElementById("app")!).render(<App />);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,3 +19,4 @@ interface ImportMeta {
 // Package metadata injected at build time via the `define` option in vite.config.ts
 declare const __APP_NAME__: string;
 declare const __APP_VERSION__: string;
+declare const __APP_COMMIT__: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -15,3 +15,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Package metadata injected at build time via the `define` option in vite.config.ts
+declare const __APP_NAME__: string;
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,18 @@ import favicons from "@peterek/vite-plugin-favicons";
 import react from "@vitejs/plugin-react";
 import type { UserConfig } from "vite";
 import { defineConfig } from "vite";
+import pkg from "./package.json";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
   return {
     plugins: [react(), favicons("public/assets/img/favicon-32x32.png")],
+    // Inject just the package metadata the app needs, instead of letting the
+    // bundler inline the whole package.json.
+    define: {
+      __APP_NAME__: JSON.stringify(pkg.name),
+      __APP_VERSION__: JSON.stringify(pkg.version),
+    },
     server: {
       // Bind to all interfaces so the dev server is reachable through the
       // forwarded port when running inside a container/devcontainer.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,29 @@ import favicons from "@peterek/vite-plugin-favicons";
 import react from "@vitejs/plugin-react";
 import type { UserConfig } from "vite";
 import { defineConfig } from "vite";
+import { execSync } from "node:child_process";
 import pkg from "./package.json";
+
+// Resolved at build time: from GITHUB_SHA in CI, from git locally. The Docker
+// build has neither (.dockerignore excludes .git and the alpine image has no
+// git), so it degrades to "unknown" instead of failing the build.
+// Slicing the full SHA, rather than `git rev-parse --short`, is what guarantees
+// exactly 7 characters: git widens the abbreviation as the repo grows.
+function resolveCommitHash(): string {
+  const fromCI = process.env.GITHUB_SHA;
+  if (fromCI) return fromCI.slice(0, 7);
+
+  try {
+    return execSync("git rev-parse HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim()
+      .slice(0, 7);
+  } catch {
+    return "unknown";
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
@@ -13,6 +35,7 @@ export default defineConfig(() => {
     define: {
       __APP_NAME__: JSON.stringify(pkg.name),
       __APP_VERSION__: JSON.stringify(pkg.version),
+      __APP_COMMIT__: JSON.stringify(resolveCommitHash()),
     },
     server: {
       // Bind to all interfaces so the dev server is reachable through the


### PR DESCRIPTION
Closes #643

## What changes

**`build: remove package.json imports`** — drops `import packageJson from "../package.json"` in `src/main.tsx`. Name and version now come from two build-time global constants (`__APP_NAME__`, `__APP_VERSION__`) injected through Vite's `define` option, so the production bundle no longer inlines the whole manifest (dependencies, scripts, jest/release-it configuration).

**`feat: add commit hash to application metadata and log`** — adds a third constant, `__APP_COMMIT__`, carrying the 7-character short commit hash, so a deployed build can be identified from the browser console at a glance: `publiccode-editor 2.1.1 (<short sha>)`. It is resolved from `GITHUB_SHA` in CI and from `git rev-parse HEAD` locally, and falls back to `unknown` in the Docker build — where `.dockerignore` excludes `.git` and the alpine build stage has no git — instead of breaking the build.

Two details worth flagging for review:

- The full SHA is sliced to 7 characters rather than using `git rev-parse --short`, because git widens the abbreviation as the repository grows: it already returns 8 characters here, so `--short` would not give a stable width.
- `define` performs a textual substitution, so every value goes through `JSON.stringify`.

## Verification

- `tsc -b`, `npm run lint` and `npm run test` (12 suites / 82 tests) are green.
- After `npm run build`, the bundle contains the `publiccode-editor <version> (<short sha>)` log line, and no longer contains `release-it`, `@swc/jest` or `patch-package` — strings that were previously inlined through the `package.json` import.
- `GIT_DIR=/dev/null npm run build` produces a bundle printing `(unknown)`, confirming the Docker fallback path does not break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
